### PR TITLE
Réorganise le HUD et ajuste la mise en forme des pages centrées

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -24,7 +24,6 @@
 
   // DOM
   const btnSave = document.getElementById('btn-save');
-  const loadThemeInput = document.getElementById('load-theme-input'); // New
   const saveThemeBtn = document.getElementById('save-theme-btn');     // New
   const exportHtmlBtn = document.getElementById('export-html-btn'); // New
   const zoomSlider = document.getElementById('zoom-slider');
@@ -607,7 +606,6 @@ function readPanelToConfig(){
     }
   });
 
-  loadThemeInput.addEventListener('change', (ev) => handleThemeFile(ev.target.files && ev.target.files[0]));
   saveThemeBtn.addEventListener('click', ()=>{
     const data={...cfg};
     delete data.markdownContent;
@@ -625,8 +623,6 @@ function readPanelToConfig(){
       readPanelToConfig();
     });
   });
-
-  function tryApplyThemeText(text){ try{ const theme=JSON.parse(text); if(theme.googleFonts) injectGoogleFonts(theme.googleFonts); cfg={...MINIMAL_CONFIG, ...theme}; populatePanel(); readPanelToConfig(); } catch{ alert('Thème invalide (JSON)'); } }
 
   function boot(){
     try{
@@ -931,6 +927,10 @@ function readPanelToConfig(){
         .title { font-size: var(--title-size); line-height: 0.95; font-weight: 700; letter-spacing: -0.5px; font-family: var(--title-font); color: var(--title-color); margin-bottom: 8px; }
         .subtitle { font-size: var(--subtitle-size); opacity: 0.85; margin-top: 0; font-family: var(--body-font); color: var(--text); }
         .body { margin-top: var(--gutter); font-size: var(--body-size); line-height: var(--line); align-self: start; justify-self: center; width: 100%; max-width: 780px; font-family: var(--body-font); color: var(--text); }
+        .text-pane.center .body { display: flex; flex-direction: column; align-items: center; width: 100%; }
+        .text-pane.center .body > * { width: 100%; }
+        .text-pane.center .md pre { align-self: center; margin-left: auto; margin-right: auto; text-align: left; width: auto; max-width: 100%; }
+        .text-pane.center .md pre code { text-align: left; display: block; }
         .body p { margin: 0 0 calc(var(--gutter) / 2); }
         strong, b { color: var(--bold-text-color); }
         em, i { color: var(--accent); font-style: italic; }
@@ -938,9 +938,9 @@ function readPanelToConfig(){
         .md table { border-collapse: collapse; width: 100%; }
         .md th, .md td { border: 1px solid #ffffff33; padding: 6px 10px; text-align: left; }
         .md img { max-width: 100%; height: auto; display: block; margin: 0 auto; border-radius: 8px; }
-        .md pre { background-color: #282c34; color: #abb2bf; padding: 1em; border-radius: 8px; overflow-x: auto; font-family: 'Fira Code', 'Courier New', Courier, monospace; font-size: 0.9em; }
+        .md pre { background-color: #282c34; color: #abb2bf; padding: 1em; border-radius: 8px; overflow-x: auto; font-family: 'Fira Code', 'Courier New', Courier, monospace; font-size: 0.9em; text-align: left; }
         .md code:not(pre code) { background-color: #282c34; color: #abb2bf; padding: .2em .4em; border-radius: 4px; font-size: 0.9em; }
-        .md pre code { background-color: transparent; padding: 0; color: inherit; font-size: inherit; }
+        .md pre code { background-color: transparent; padding: 0; color: inherit; font-size: inherit; text-align: left; display: block; }
         .md .mermaid { display: block; margin: 1.5em 0; }
         .vspace { width: 100%; }
         img { max-width: 100%; border-radius: 8px; height: auto; }

--- a/app/styles.css
+++ b/app/styles.css
@@ -8,10 +8,11 @@
 *{box-sizing:border-box} html,body,#app{height:100%;margin:0}
 body{background:var(--bg);color:var(--text);font-family:Arial, sans-serif;}
 
-#hud{position:fixed;top:12px;right:12px;display:flex;flex-wrap:wrap;gap:8px;align-items:center;z-index:210;max-width:500px;justify-content:flex-end; background: rgba(0,0,0,0.7); border-radius:10px; overflow: hidden; padding: 8px 12px;}
-#hud button,#hud .file-btn{background:#ffffff22;color:#fff;border:0;padding:6px 10px;border-radius:10px;cursor:pointer}
-#hud .file-btn{position:relative;overflow:hidden}
-#hud .file-btn input{position:absolute;inset:0;opacity:0;cursor:pointer}
+#hud{position:fixed;top:12px;right:12px;display:flex;flex-direction:column;gap:8px;align-items:stretch;z-index:210;max-width:500px;background:rgba(0,0,0,0.7);border-radius:10px;padding:12px;}
+#hud .hud-row{display:flex;gap:8px;justify-content:flex-end;align-items:center;width:100%;}
+#hud .hud-row.hud-primary{flex-wrap:nowrap;}
+#hud .hud-row.hud-secondary{flex-wrap:wrap;}
+#hud button{background:#ffffff22;color:#fff;border:0;padding:6px 10px;border-radius:10px;cursor:pointer;flex-shrink:0;}
 #pos{color:#fff;padding:4px 8px;border-radius:10px;background:#ffffff22;font-size:12px}
 
 #slider-controls{position:fixed;bottom:12px;right:12px;display:flex;flex-direction:column;gap:8px;background: rgba(0,0,0,0.7);padding:10px;border-radius:10px;z-index:210;font-size:12px;color:#fff;backdrop-filter:blur(4px);}
@@ -126,6 +127,10 @@ body.hide-ui #hud, body.hide-ui .panel, body.hide-ui #slider-controls { display:
 
 .text-pane .title { margin-bottom: 8px; /* Add a small gap between title and subtitle */ }
 .text-pane .body{margin-top:var(--gutter);font-size:var(--body-size);line-height:var(--line);align-self:start;justify-self:center;width:100%;max-width:780px;font-family:var(--body-font); color: var(--text);}
+.text-pane.center .body{display:flex;flex-direction:column;align-items:center;width:100%;}
+.text-pane.center .body>*{width:100%;}
+.text-pane.center .md pre{align-self:center;margin-left:auto;margin-right:auto;text-align:left;width:auto;max-width:100%;}
+.text-pane.center .md pre code{text-align:left;display:block;}
 
 .text-pane strong, .text-pane b { color: var(--bold-text-color); }
 .text-pane em, .text-pane i { color: var(--accent); font-style: italic; }
@@ -209,6 +214,7 @@ body.hide-ui #hud, body.hide-ui .panel, body.hide-ui #slider-controls { display:
   overflow-x: auto;
   font-family: 'Fira Code', 'Courier New', Courier, monospace; /* Common coding fonts */
   font-size: 0.9em;
+  text-align: left;
 }
 
 .text-pane .md code:not(pre code) {
@@ -224,4 +230,6 @@ body.hide-ui #hud, body.hide-ui .panel, body.hide-ui #slider-controls { display:
   padding: 0;
   color: inherit;
   font-size: inherit;
+  text-align: left;
+  display: block;
 }

--- a/index.html
+++ b/index.html
@@ -14,16 +14,19 @@
 <body>
   <div id="app">
     <div id="hud">
-      <button id="prev" type="button">◀︎</button>
-      <div id="pos">1/1</div>
-      <button id="next" type="button">▶︎</button>
-      <button id="invert-layout-btn" type="button" style="display: none;">↔ Inverser</button>
-      <button id="btn-save" type="button">Sauvegarder la présentation</button>
-      <label class="file-btn small" id="load-theme-btn-label">Charger un thème<input type="file" id="load-theme-input" accept=".json"/></label>
-      <button id="save-theme-btn" type="button">Sauvegarder le thème</button>
-      <button id="export-html-btn" type="button">Télécharger la présentation</button>
-      <button id="openPanelText" type="button">🎨 Textes</button>
-      <button id="openPanelEffects" type="button">✨ Effets</button>
+      <div class="hud-row hud-primary">
+        <button id="prev" type="button">◀︎</button>
+        <div id="pos">1/1</div>
+        <button id="next" type="button">▶︎</button>
+        <button id="openPanelText" type="button">🎨 Textes</button>
+        <button id="openPanelEffects" type="button">✨ Effets</button>
+      </div>
+      <div class="hud-row hud-secondary">
+        <button id="invert-layout-btn" type="button" style="display: none;">↔ Inverser</button>
+        <button id="btn-save" type="button">Sauvegarder la présentation</button>
+        <button id="save-theme-btn" type="button">Sauvegarder le thème</button>
+        <button id="export-html-btn" type="button">Télécharger la présentation</button>
+      </div>
     </div>
 
     <div id="slider-controls">


### PR DESCRIPTION
## Summary
- organise le HUD en deux rangées afin de regrouper la navigation avec les boutons Textes/Effets et de retirer l’import de thème devenu inutile
- centre les contenus des diapositives sans image, y compris les blocs de code dont le texte reste aligné à gauche
- aligne les styles exportés et supprime la logique JavaScript liée au chargement de thème

## Testing
- not run (static web app)


------
https://chatgpt.com/codex/tasks/task_b_68cd070be29c8322b3415ab08096f06f